### PR TITLE
Adding a callback to touch function to prevent the error: wrong number of arguments for 'expire' command

### DIFF
--- a/lib/jwtRedisSession.js
+++ b/lib/jwtRedisSession.js
@@ -52,7 +52,11 @@ module.exports = function(options){
 					req[options.requestKey].claims = decoded;
 					req[options.requestKey].id = decoded.jti;
 					req[options.requestKey].jwt = token;
-					req[options.requestKey].touch(); // update the TTL
+					req[options.requestKey].jwt = token;
+					// Update the TTL
+					req[options.requestKey].touch(function(err, result){
+						// Nothing to do here
+					});
 					next();
 				});
 			});


### PR DESCRIPTION
I'm using redis with hiredis parser and i'm getting the follow error:
````
closic-1 Unhandled rejection Error: ERR wrong number of arguments for 'expire' command
closic-1     at Error (native)
closic-1     at HiredisReplyParser.return_data (/opt/applications/closic/node_modules/redis/lib/parsers/hiredis.js:14:28)
closic-1     at HiredisReplyParser.execute (/opt/applications/closic/node_modules/redis/lib/parsers/hiredis.js:24:22)
closic-1     at Socket.<anonymous> (/opt/applications/closic/node_modules/redis/index.js:131:27)
closic-1     at emitOne (events.js:78:13)
closic-1     at Socket.emit (events.js:170:7)
closic-1     at readableAddChunk (_stream_readable.js:147:16)
closic-1     at Socket.Readable.push (_stream_readable.js:111:10)
closic-1     at TCP.onread (net.js:524:20)
````