### PR TITLE
support koa2 middleware

### DIFF
--- a/lib/jwtRedisSession.js
+++ b/lib/jwtRedisSession.js
@@ -20,6 +20,7 @@ module.exports = function(options){
 		requestKey: "session",
 		requestArg: "accessToken",
 		tokenKey: "jwt",
+		jtiKey : 'jti',
 		keepRequestArgHeader: false,
 		useCookies: false
 	});
@@ -34,7 +35,61 @@ module.exports = function(options){
 		}, "x" + (options.requestArg.charAt(0) === options.requestArg.charAt(0).toUpperCase() ? "" : "-"));
 	}
 
-	return function jwtRedisSession(req, res, next){
+    let koaTokenHandler = async(token, ctx, next) => {
+        let req = ctx;
+        if (token) {
+
+            try {
+
+                let decoded = await new Promise((resolve, reject) => {
+
+                    jwt.verify(token, options.secret, (err, decoded) => {
+                        if (err || !decoded[options.jtiKey]) {
+                            reject();
+                        }
+
+                        resolve(decoded);
+                    });
+                });
+
+                let session = await options.client.getAsync(options.keyspace + decoded[options.requestKey]);
+
+                session = JSON.parse(session);
+
+                _.extend(req[options.requestKey], session);
+                req[options.requestKey].claims = decoded;
+                req[options.requestKey].id = decoded[options.jtiKey];
+                req[options.requestKey][options.tokenKey] = token;
+                // Update the TTL
+                req[options.requestKey].touch(_.noop);
+
+            } catch (e) {
+                // donothing
+                debug(e);
+            }
+
+        }
+
+        await next();
+    }
+
+    let koaJwtRedisSession = async function(ctx, next) {
+
+        ctx[options.requestKey] = new SessionUtils();
+
+        var token = ctx.header[options.requestArg] ||
+            ctx.query[options.requestArg] ||
+            (ctx.body && ctx.body[options.requestArg]);
+
+        if(!token && options.useCookies){
+            token = req.cookies[options.requestArg];
+        }
+
+        await koaTokenHandler(token, ctx, next);
+
+    }
+
+	let jwtRedisSession = function(req, res, next){
 
 		req[options.requestKey] = new SessionUtils();
 
@@ -69,7 +124,7 @@ module.exports = function(options){
 
 					_.extend(req[options.requestKey], session);
 					req[options.requestKey].claims = decoded;
-					req[options.requestKey].id = decoded.jti;
+                    req[options.requestKey].id = decoded[options.jtiKey];
 					req[options.requestKey][options.tokenKey] = token;
 					// Update the TTL
 					req[options.requestKey].touch(_.noop);
@@ -80,5 +135,9 @@ module.exports = function(options){
 			next(); 
 		}
 	};
+
+    jwtRedisSession.koa = koaJwtRedisSession;
+
+    return jwtRedisSession;
 
 };


### PR DESCRIPTION
just add "koa" to jwtRedisSession
use like 
```
var JWTRedisSession = require("jwt-redis-session"),
	Koa = require("koa"),
	redis = require("redis");

var redisClient = redis.createClient(),
	secret = generateSecretKeySomehow(),
	app = Koa();

app.use(JWTRedisSession({
	client: redisClient,
	secret: secret,
	keyspace: "sess:", 
	maxAge: 86400,
	algorithm: "HS256",
	requestKey: "jwtSession",
	requestArg: "jwtToken"
}).koa);
```