### PR TITLE
Remove unecessary path dependency and path.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,1 @@
-
-var path = require("path");
-
-module.exports = require(path.join(__dirname, "lib/jwtRedisSession"));
+module.exports = require("./lib/jwtRedisSession"));


### PR DESCRIPTION
Very small modification, but useful for all users of IDE, as it breaks the convention of requires in node.
Many IDE provides useful infos with the conventional way of doing requires.