### PR TITLE
Update jsonwebtoken version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha test/tests.js"
   },
   "dependencies": {
-    "jsonwebtoken": "^7.1.9",
+    "jsonwebtoken": "^8.0.0",
     "lodash": "^4.16.1",
     "node-uuid": "^1.4.1"
   },


### PR DESCRIPTION
This resolves a vulnerability reported against to the hoek dependency which is no longer in use in jsonwebtoken v8.0.0
https://www.npmjs.com/advisories/566

The use should not be affected by the breaking changes from 7 to 8:
https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v7-to-v8